### PR TITLE
Added printing of stats to screen

### DIFF
--- a/framebuffer.c
+++ b/framebuffer.c
@@ -29,6 +29,9 @@ int fb_alloc(struct fb** framebuffer, unsigned int width, unsigned int height) {
 	fb->numa_node = get_numa_node();
 	fb->list = LLIST_ENTRY_INIT;
 
+	fb->pixel_counter = 0;
+	fb->byte_counter = 0;
+
 	*framebuffer = fb;
 	return 0;
 
@@ -69,6 +72,7 @@ void fb_set_pixel(struct fb* fb, unsigned int x, unsigned int y, union fb_pixel*
 
 	target = &(fb->pixels[y * fb->size.width + x]);
 	memcpy(target, pixel, sizeof(*pixel));
+	fb->pixel_counter++;
 }
 
 void fb_set_pixel_rgb(struct fb* fb, unsigned int x, unsigned int y, uint8_t red, uint8_t green, uint8_t blue) {
@@ -80,6 +84,7 @@ void fb_set_pixel_rgb(struct fb* fb, unsigned int x, unsigned int y, uint8_t red
 	target->color.color_bgr.red = red;
 	target->color.color_bgr.green = green;
 	target->color.color_bgr.blue = blue;
+	fb->pixel_counter++;
 }
 
 // It might be a good idea to offer a variant returning a pointer to avoid unnecessary copies
@@ -127,6 +132,9 @@ int fb_coalesce(struct fb* fb, struct llist* fbs) {
 	struct fb* other;
 	size_t i, j, fb_size = fb->size.width * fb->size.height, num_fbs = llist_length(fbs);
 	unsigned int indices[num_fbs];
+	unsigned long long global_pixel_counter = 0;
+	unsigned long long global_byte_counter = 0;
+
 	for(i = 0; i < num_fbs; i++) {
 		indices[i] = i;
 	}
@@ -146,6 +154,10 @@ int fb_coalesce(struct fb* fb, struct llist* fbs) {
 			// Reset to fully transparent
 			other->pixels[j].color.alpha = 0;
 		}
+		global_pixel_counter += other->pixel_counter;
+		global_byte_counter += other->byte_counter;
 	}
+	fb->pixel_counter = global_pixel_counter;
+	fb->byte_counter = global_byte_counter;
 	return 0;
 }

--- a/framebuffer.h
+++ b/framebuffer.h
@@ -33,6 +33,8 @@ struct fb {
 	union fb_pixel* pixels;
 	unsigned numa_node;
 	struct llist_entry list;
+	unsigned long long pixel_counter;
+	unsigned long long byte_counter;
 };
 
 

--- a/network.c
+++ b/network.c
@@ -313,6 +313,7 @@ recv:
 			goto fail_ring;
 		}
 //		printf("Read %zd bytes\n", read_len);
+		fb->byte_counter += read_len;
 		ring_advance_write(ring, read_len);
 
 		while(ring_any_available(ring)) {


### PR DESCRIPTION
Hi,
i've redone my first pull request to match some naming conventions and to use the new custom fonts feature.
This PR adds printing of fps, server load, Network and Pixel-stats to the screen.
The only problem are the missing background color of the text, this actually looks kind of weird (see image).
It would be nice, if you could add an background color to the text or give an hint what's in your opinion the best way to do this.
![Screenshot](https://user-images.githubusercontent.com/29303194/69036489-4ef49000-09e6-11ea-8362-c877f5a41bdc.png)
