### PR TITLE
Added error message when listen address of statistics frontend cant be resolved

### DIFF
--- a/statistics.c
+++ b/statistics.c
@@ -226,6 +226,7 @@ static int statistics_frontend_start(struct frontend* front) {
 	struct sockaddr_storage* listen_addr;
 
 	if((err = -getaddrinfo(sfront->listen_address, sfront->listen_port, NULL, &addr_list))) {
+		fprintf(stderr, "Failed to resolve listen address for statistics '%s', %d => %s\n", sfront->listen_address, err, gai_strerror(-err));
 		goto fail;
 	}
 	sfront->addr_list = addr_list;


### PR DESCRIPTION
Trying to start a statistics frontend in a system without IPv6 (default listen address is "::") silently fails.
Added descriptive error message